### PR TITLE
[Vivado] Export VTA configuration variables to TCL for hardware builds

### DIFF
--- a/config/vta_config.py
+++ b/config/vta_config.py
@@ -52,6 +52,7 @@ def gen_target_cflags(pkg):
     return cflags_str
 
 def calculate_num_wgt_uram(pkg):
+    """Calculate number of weight uram from config"""
     if hasattr(pkg, 'num_wgt_mem_uram'):
         return pkg.num_wgt_mem_uram
     else:

--- a/config/vta_config.py
+++ b/config/vta_config.py
@@ -116,8 +116,6 @@ def main():
                         help="print the target")
     parser.add_argument("--cfg-str", action="store_true",
                         help="print the configuration string")
-    parser.add_argument("--build-path", action="store_true",
-                        help="print build path")
     parser.add_argument("--get-inp-mem-banks", action="store_true",
                         help="returns number of input memory banks")
     parser.add_argument("--get-inp-mem-width", action="store_true",
@@ -216,9 +214,6 @@ def main():
 
     if args.cfg_str:
         print(pkg.TARGET + "_" + pkg.bitstream)
-
-    if args.build_path:
-        print(pkg.build_path)
 
     if args.get_inp_mem_banks:
         print(pkg.inp_mem_banks)

--- a/hardware/xilinx/Makefile
+++ b/hardware/xilinx/Makefile
@@ -34,6 +34,9 @@ CONF := $(shell python ${VTA_CONFIG} --cfg-str)
 IP_BUILD_PATH := $(BUILD_DIR)/hls/$(CONF)
 HW_BUILD_PATH := $(BUILD_DIR)/vivado/$(CONF)
 
+# Config files
+CONFIG_TCL = $(BUILD_DIR)/include/vta_config.tcl
+
 # IP file path
 IP_PATH := $(BUILD_DIR)/hls/$(CONF)/vta_compute/soln/impl/ip/xilinx_com_hls_compute_1_0.zip
 
@@ -46,14 +49,20 @@ all: bit
 ip: $(IP_PATH)
 bit: $(BIT_PATH)
 
-$(IP_PATH): $(SRC_DIR)/*
+$(BUILD_DIR)/include:
+	mkdir -p $@
+
+$(CONFIG_TCL): | $(BUILD_DIR)/include
+	python $(VTA_CONFIG) --export-tcl $@
+
+$(IP_PATH): $(SRC_DIR)/* $(CONFIG_TCL)
 	mkdir -p $(IP_BUILD_PATH)
 	cd $(IP_BUILD_PATH) && \
 		$(VIVADO_HLS) \
 		-f $(SCRIPT_DIR)/hls.tcl \
 		-tclargs \
 			$(VTA_HW_DIR) \
-			${VTA_CONFIG}
+			$(CONFIG_TCL)
 
 $(BIT_PATH): $(IP_PATH)
 	mkdir -p $(HW_BUILD_PATH)
@@ -63,7 +72,7 @@ $(BIT_PATH): $(IP_PATH)
 		-source $(SCRIPT_DIR)/vivado.tcl \
 		-tclargs \
 			$(BUILD_DIR)/hls/$(CONF) \
-			${VTA_CONFIG}
+			$(CONFIG_TCL)
 
 clean:
 	rm -rf *.out *.log

--- a/hardware/xilinx/scripts/hls.tcl
+++ b/hardware/xilinx/scripts/hls.tcl
@@ -32,21 +32,24 @@ set src_dir "$root_dir/hardware/xilinx/src"
 set sim_dir "$root_dir/hardware/xilinx/sim"
 set test_dir "$root_dir/tests/hardware/common"
 
+# Source vta config variables
+source $vta_config
+
 # C define flags that we want to pass to the compiler
-set cflags [exec python $vta_config --cflags]
+set cflags $CFLAGS
 
 # Get the VTA configuration paramters
-set ::device        [exec python $vta_config --get-fpga-dev]
-set ::period        [exec python $vta_config --get-fpga-per]
+set ::device $FPGA_DEVICE
+set ::period $FPGA_PERIOD
 
 # Get the VTA SRAM reshape/partition factors to get all memories
 # to be of the same axi width.
-set ::inp_reshape_factor    [exec python $vta_config --get-inp-mem-axi-ratio]
-set ::inp_partition_factor  [exec python $vta_config --get-inp-mem-banks]
-set ::wgt_reshape_factor    [exec python $vta_config --get-wgt-mem-axi-ratio]
-set ::wgt_partition_factor  [exec python $vta_config --get-wgt-mem-banks]
-set ::out_reshape_factor    [exec python $vta_config --get-out-mem-axi-ratio]
-set ::out_partition_factor  [exec python $vta_config --get-out-mem-banks]
+set ::inp_reshape_factor    $INP_MEM_AXI_RATIO
+set ::inp_partition_factor  $INP_MEM_BANKS
+set ::wgt_reshape_factor    $WGT_MEM_AXI_RATIO
+set ::wgt_partition_factor  $WGT_MEM_BANKS
+set ::out_reshape_factor    $OUT_MEM_AXI_RATIO
+set ::out_partition_factor  $OUT_MEM_BANKS
 
 
 # Initializes the HLS design and sets HLS pragmas for memory partitioning.

--- a/hardware/xilinx/scripts/vivado.tcl
+++ b/hardware/xilinx/scripts/vivado.tcl
@@ -35,33 +35,37 @@ if { [llength $argv] eq 2 } {
   return 1
 }
 
+# Source vta config variables
+source $vta_config
+
 # Get the VTA configuration paramters
-set target            [exec python $vta_config --target]
-set device_family     [exec python $vta_config --get-fpga-family]
-set clock_freq        [exec python $vta_config --get-fpga-freq]
+set target            $TARGET
+set device            $FPGA_DEVICE
+set device_family     $FPGA_FAMILY
+set clock_freq        $FPGA_FREQ
 
 # SRAM dimensions
-set inp_part          [exec python $vta_config --get-inp-mem-banks]
-set inp_mem_width     [exec python $vta_config --get-inp-mem-width]
-set inp_mem_depth     [exec python $vta_config --get-inp-mem-depth]
-set wgt_part          [exec python $vta_config --get-wgt-mem-banks]
-set wgt_mem_width     [exec python $vta_config --get-wgt-mem-width]
-set wgt_mem_depth     [exec python $vta_config --get-wgt-mem-depth]
-set out_part          [exec python $vta_config --get-out-mem-banks]
-set out_mem_width     [exec python $vta_config --get-out-mem-width]
-set out_mem_depth     [exec python $vta_config --get-out-mem-depth]
-set num_wgt_mem_uram  [exec python $vta_config --get-num-wgt-mem-uram]
+set inp_part          $INP_MEM_BANKS
+set inp_mem_width     $INP_MEM_WIDTH
+set inp_mem_depth     $INP_MEM_DEPTH
+set wgt_part          $WGT_MEM_BANKS
+set wgt_mem_width     $WGT_MEM_WIDTH
+set wgt_mem_depth     $WGT_MEM_DEPTH
+set out_part          $OUT_MEM_BANKS
+set out_mem_width     $OUT_MEM_WIDTH
+set out_mem_depth     $OUT_MEM_DEPTH
+set num_wgt_mem_uram  $NUM_WGT_MEM_URAM
 
 # AXI bus signals
-set axi_cache         [exec python $vta_config --get-axi-cache-bits]
-set axi_prot          [exec python $vta_config --get-axi-prot-bits]
+set axi_cache         $AXI_CACHE_BITS
+set axi_prot          $AXI_PROT_BITS
 
 # Address map
-set ip_reg_map_range  [exec python $vta_config --get-ip-reg-map-range]
-set fetch_base_addr   [exec python $vta_config --get-fetch-base-addr]
-set load_base_addr    [exec python $vta_config --get-load-base-addr]
-set compute_base_addr [exec python $vta_config --get-compute-base-addr]
-set store_base_addr   [exec python $vta_config --get-store-base-addr]
+set ip_reg_map_range  $IP_REG_MAP_RANGE
+set fetch_base_addr   $FETCH_BASE_ADDR
+set load_base_addr    $LOAD_BASE_ADDR
+set compute_base_addr $COMPUTE_BASE_ADDR
+set store_base_addr   $STORE_BASE_ADDR
 
 # Paths to IP library of VTA modules
 set proj_name vta
@@ -74,7 +78,6 @@ set compute_ip "${ip_path}/vta_compute/soln/impl/ip/xilinx_com_hls_compute_1_0.z
 set store_ip "${ip_path}/vta_store/soln/impl/ip/xilinx_com_hls_store_1_0.zip"
 
 # Create custom project
-set device [exec python $vta_config --get-fpga-dev]
 create_project -force $proj_name $proj_path -part $device
 
 # Update IP repository with generated IP


### PR DESCRIPTION
Hi @tmoreau89 @liangfu,

The following PR adds support to export a TCL file from `vta_config.py` with all necessary variables for hardware-scripts i.e., Vivado. Currently, these variables are captured by invoking `vta_config.py` within the TCL script see [here](https://github.com/apache/incubator-tvm-vta/blob/master/hardware/xilinx/scripts/hls.tcl#L35-L49) and [here](https://github.com/apache/incubator-tvm-vta/blob/master/hardware/xilinx/scripts/vivado.tcl#L39-L64). The challenge with this approach is that python environment is unknown in hardware tools and we shouldn't rely in that. Instead, we can generate TCL which is what natively these tools actually support.

Additionally, I added TCL function called `const` that checks that variables are not written (read-only), otherwise it will raise an error. This is a better practice than using `set variable value` approach, since these variables are not modified in these scripts. Sadly, TCL does not support read-only-variables natively. More info about this [here](https://wiki.tcl-lang.org/page/constants).