### PR TITLE
Enable Supported Xilinx target ZCU104 with Hardware Preset

### DIFF
--- a/config/pkg_config.py
+++ b/config/pkg_config.py
@@ -152,6 +152,8 @@ class PkgConfig(object):
         elif self.TARGET == "ultra96":
             self.fpga_device = "xczu3eg-sbva484-1-e"
             self.fpga_family = "zynq-ultrascale+"
+            self.fpga_board = None
+            self.fpga_board_rev = None
             self.fpga_freq = 333
             self.fpga_per = 2
             self.fpga_log_axi_bus_width = 7
@@ -165,6 +167,8 @@ class PkgConfig(object):
         elif self.TARGET == "zcu104":
             self.fpga_device = "xczu7ev-ffvc1156-2-e"
             self.fpga_family = "zynq-ultrascale+"
+            self.fpga_board = "xilinx.com:zcu104:part0"
+            self.fpga_board_rev = "1.1"
             self.fpga_freq = 333
             self.fpga_per = 2
             self.fpga_log_axi_bus_width = 7
@@ -179,6 +183,8 @@ class PkgConfig(object):
             # By default, we use the pynq parameters
             self.fpga_device = "xc7z020clg484-1"
             self.fpga_family = "zynq-7000"
+            self.fpga_board = None
+            self.fpga_board_rev = None
             self.fpga_freq = 100
             self.fpga_per = 7
             self.fpga_log_axi_bus_width = 6

--- a/config/pkg_config.py
+++ b/config/pkg_config.py
@@ -91,7 +91,7 @@ class PkgConfig(object):
         # List of source files that can be used to build standalone library.
         self.lib_source = []
         self.lib_source += glob.glob("%s/src/*.cc" % vta_hw_path)
-        if self.TARGET in ["pynq", "ultra96"]:
+        if self.TARGET in ["pynq", "ultra96", "zcu104"]:
             # add pynq drivers for any board that uses pynq driver stack (see pynq.io)
             self.lib_source += glob.glob("%s/src/pynq/*.cc" % vta_hw_path)
         elif self.TARGET in ["de10nano"]:
@@ -102,7 +102,7 @@ class PkgConfig(object):
             ]
 
         # Linker flags
-        if self.TARGET in ["pynq", "ultra96"]:
+        if self.TARGET in ["pynq", "ultra96", "zcu104"]:
             self.ldflags = [
                 "-L/usr/lib",
                 "-l:libcma.so"]
@@ -151,6 +151,19 @@ class PkgConfig(object):
             self.store_base_addr = "0xFF223000"
         elif self.TARGET == "ultra96":
             self.fpga_device = "xczu3eg-sbva484-1-e"
+            self.fpga_family = "zynq-ultrascale+"
+            self.fpga_freq = 333
+            self.fpga_per = 2
+            self.fpga_log_axi_bus_width = 7
+            self.axi_prot_bits = '010'
+            # IP register address map
+            self.ip_reg_map_range = "0x1000"
+            self.fetch_base_addr = "0xA0000000"
+            self.load_base_addr = "0xA0001000"
+            self.compute_base_addr = "0xA0002000"
+            self.store_base_addr = "0xA0003000"
+        elif self.TARGET == "zcu104":
+            self.fpga_device = "xczu7ev-ffvc1156-2-e"
             self.fpga_family = "zynq-ultrascale+"
             self.fpga_freq = 333
             self.fpga_per = 2

--- a/config/vta_config.py
+++ b/config/vta_config.py
@@ -40,6 +40,8 @@ def gen_target_name(pkg):
         return "VTA_TARGET_DE10_NANO"
     elif pkg.TARGET == "ultra96":
         return "VTA_TARGET_ULTRA96"
+    elif pkg.TARGET == "zcu104":
+        return "VTA_TARGET_ZCU104"
     else:
         return None
 

--- a/config/vta_config.py
+++ b/config/vta_config.py
@@ -72,6 +72,8 @@ def gen_tcl_vivado(pkg, file):
         fo.write("\nconst TARGET {}".format(pkg.TARGET))
         fo.write("\nconst FPGA_DEVICE {}".format(pkg.fpga_device))
         fo.write("\nconst FPGA_FAMILY {}".format(pkg.fpga_family))
+        fo.write("\nconst FPGA_BOARD {}".format(pkg.fpga_board))
+        fo.write("\nconst FPGA_BOARD_REV {}".format(pkg.fpga_board_rev))
         fo.write("\nconst FPGA_PERIOD {}".format(pkg.fpga_per))
         fo.write("\nconst FPGA_FREQ {}".format(pkg.fpga_freq))
         fo.write("\nconst INP_MEM_AXI_RATIO {}".format(pkg.inp_mem_axi_ratio))
@@ -160,6 +162,10 @@ def main():
                         help="returns store module base address")
     parser.add_argument("--get-fpga-dev", action="store_true",
                         help="returns FPGA device target")
+    parser.add_argument("--get-fpga-board", action="store_true",
+                        help="returns FPGA board")
+    parser.add_argument("--get-fpga-board-rev", action="store_true",
+                        help="returns FPGA board version")
     parser.add_argument("--get-fpga-family", action="store_true",
                         help="returns FPGA device family")
     parser.add_argument("--get-fpga-freq", action="store_true",
@@ -282,6 +288,12 @@ def main():
 
     if args.get_fpga_family:
         print(pkg.fpga_family)
+
+    if args.get_fpga_board:
+        print(pkg.fpga_board)
+
+    if args.get_fpga_board_rev:
+        print(pkg.fpga_board_rev)
 
     if args.get_fpga_freq:
         print(pkg.fpga_freq)

--- a/config/zcu104_sample.json
+++ b/config/zcu104_sample.json
@@ -1,0 +1,13 @@
+{
+  "TARGET" : "zcu104",
+  "HW_VER" : "0.0.1",
+  "LOG_INP_WIDTH" : 3,
+  "LOG_WGT_WIDTH" : 3,
+  "LOG_ACC_WIDTH" : 5,
+  "LOG_BATCH" : 0,
+  "LOG_BLOCK" : 4,
+  "LOG_UOP_BUFF_SIZE" : 15,
+  "LOG_INP_BUFF_SIZE" : 15,
+  "LOG_WGT_BUFF_SIZE" : 18,
+  "LOG_ACC_BUFF_SIZE" : 17
+}

--- a/hardware/xilinx/scripts/vivado.tcl
+++ b/hardware/xilinx/scripts/vivado.tcl
@@ -43,6 +43,8 @@ set target            $TARGET
 set device            $FPGA_DEVICE
 set device_family     $FPGA_FAMILY
 set clock_freq        $FPGA_FREQ
+set board             $FPGA_BOARD
+set board_rev         $FPGA_BOARD_REV
 
 # SRAM dimensions
 set inp_part          $INP_MEM_BANKS
@@ -79,6 +81,11 @@ set store_ip "${ip_path}/vta_store/soln/impl/ip/xilinx_com_hls_store_1_0.zip"
 
 # Create custom project
 create_project -force $proj_name $proj_path -part $device
+
+# Apply board preset if exists
+if {$board != "None" && $board_rev != "None"} {
+  set_property board_part $board:$board_rev [current_project]
+}
 
 # Update IP repository with generated IP
 file mkdir $ip_lib
@@ -298,10 +305,12 @@ if { $device_family eq "zynq-7000" } {
   set saxi      [get_bd_intf_pins processing_system/S_AXI_ACP]
 } elseif { $device_family eq "zynq-ultrascale+" } {
   set processing_system [ create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:3.3 processing_system ]
+  apply_bd_automation -rule xilinx.com:bd_rule:zynq_ultra_ps_e -config {apply_board_preset "1" }  [get_bd_cells processing_system]
   set_property -dict [ list \
     CONFIG.PSU__FPGA_PL0_ENABLE {1} \
     CONFIG.PSU__CRL_APB__PL0_REF_CTRL__FREQMHZ {100} \
     CONFIG.PSU__USE__M_AXI_GP0 {1} \
+    CONFIG.PSU__USE__M_AXI_GP1 {0} \
     CONFIG.PSU__USE__M_AXI_GP2 {0} \
     CONFIG.PSU__USE__S_AXI_GP0 {1}
   ] $processing_system


### PR DESCRIPTION
This commit adds support for the Xilinx zcu104 development board.
Currently, TVM-VTA does not support a production board thus this
commit. Leveraging a supported board which is integrated into Vivado
provides board presets properly configuring peripherals and IO for
development. This means that the project can be used for further
bsp development using the XSA.

Also, enable fpga_board and fpga_board_ver properties for
Xilinx Platforms. This enables the hardware project to
produce a usable XSA which contains the board presets.
The board preset contains board specific config such as
IO/PS/DDR settings.

The end goal of this commit is to allow the output products
of TVM-VTA to be used in bsp creation and.. produce more
meaningful output products.

