### PR TITLE
pynq: Update pynq driver control logic

### DIFF
--- a/src/pynq/pynq_driver.h
+++ b/src/pynq/pynq_driver.h
@@ -57,6 +57,8 @@ uint32_t VTAReadMappedReg(void* base_addr, uint32_t offset);
 #define VTA_START 0x1
 /*! \brief VTA configuration register auto-restart value */
 #define VTA_AUTORESTART 0x81
+/*! \brief VTA configuration register auto-restart disable value */
+#define VTA_AUTORESTART_DISABLE 0x0
 /*! \brief VTA configuration register done value */
 #define VTA_DONE 0x1
 


### PR DESCRIPTION
An update is needed in the pynq driver to control
VTA. Once VTA is started it is necessary to wait
for fetch ap_done signal prior to reading compute
done flag. Also, the autorestart IPs need to be
disabled when complete as well as good practice. 
This logic change will enable a more performant 
execution by removing the sleep logic.