### PR TITLE
Make VTA C++ Deploy Compatible with latest TVM.

### DIFF
--- a/apps/deploy/Makefile
+++ b/apps/deploy/Makefile
@@ -28,7 +28,7 @@ ifeq (${TARGET}, sim)
 	VTA_LIB=vta_fsim
 endif
 
-PKG_CFLAGS = -std=c++11 -O0 -g -fPIC\
+PKG_CFLAGS = -std=c++14 -O0 -g -fPIC\
 						 -I${TVM_ROOT}/include\
 						 -I${TVM_ROOT}/vta/include\
 						 -I${DMLC_CORE}/include\


### PR DESCRIPTION
Issue:
c++ deployment get broken after recently TVM change,
first issue is lastest TVM use some c++14 feature in
header file that caused current compile fail.

second issue is lastest TVM did more strict format/type
check that make the restnet export logic failed.

Solution:
Fix the said issue to make logic work.